### PR TITLE
POL bug #4918

### DIFF
--- a/PlayOnLinux_Packager/generate_deb
+++ b/PlayOnLinux_Packager/generate_deb
@@ -96,7 +96,7 @@ Section: misc
 Priority: optional
 Installed-Size: $installed_size
 Architecture: all
-Depends: unzip, wine | wine-stable | wine-unstable | wine:i386 | wine-stable:i386 | wine-unstable:i386, wget, xterm, python, python-wxgtk2.8, imagemagick, cabextract, icoutils, p7zip-full
+Depends: unzip, wine | wine-stable | wine-development | wine:i386 | wine-stable:i386 | wine-development:i386, wget, xterm, python, python-wxgtk2.8, imagemagick, cabextract, icoutils, p7zip-full
 Maintainer: PlayOnLinux Packaging <packages@playonlinux.com>
 Description: This program is a front-end for wine.
  It permits you to install Windows Games and softwares


### PR DESCRIPTION
Debian changed the name of 'wine-unstable' to 'wine-development'. I have made the changes after confirming this in their repository.
